### PR TITLE
feat: t14 - docker oom

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+-   repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+    -   id: hadolint-docker

--- a/chapter4/tests/t14/Dockerfile
+++ b/chapter4/tests/t14/Dockerfile
@@ -21,7 +21,7 @@ RUN python -m venv /venv && \
  /venv/bin/pip install --no-cache-dir -r /app/requirements.txt
 
 # Create distroless container.
-FROM gcr.io/distroless/python3-debian11@sha256:57dbab565d405ce5ae9c7a8c781c95fa229655cb8381d0e5db4ece28661fa687
+FROM gcr.io/distroless/python3-debian11:latest-amd64
 COPY --from=builder /venv /venv
 COPY ./testtask /app
 WORKDIR /app

--- a/chapter4/tests/t14/Dockerfile
+++ b/chapter4/tests/t14/Dockerfile
@@ -1,0 +1,29 @@
+# -----------------------------------------------
+# The created image contains Python application that
+# tries to allocate a lot of memory cause container OOM.
+#
+# You can run it like this:
+# docker run --rm -m 30m --name oom krasninja/python-oom:0.1.0
+#
+# The image will be terminated. Then you can check the
+# exit status:
+# docker inspect oom | jq ".[].State"
+#
+# The "OOMKilled" flag should be "true".
+# -----------------------------------------------
+
+
+# Prepare Python builder and prepare virtual env with necessary packages.
+FROM python:3.11-slim AS builder
+COPY ./testtask/requirements.txt /app/requirements.txt
+RUN python -m venv /venv && \
+ /venv/bin/pip install --upgrade --no-cache-dir pip && \
+ /venv/bin/pip install --no-cache-dir -r /app/requirements.txt
+
+# Create distroless container.
+FROM gcr.io/distroless/python3-debian11@sha256:57dbab565d405ce5ae9c7a8c781c95fa229655cb8381d0e5db4ece28661fa687
+COPY --from=builder /venv /venv
+COPY ./testtask /app
+WORKDIR /app
+ENV PYTHONPATH="/venv/lib/python3.11/site-packages:$PYTHONPATH"
+ENTRYPOINT ["/usr/bin/python3", "memory.py"]

--- a/chapter4/tests/t14/Makefile
+++ b/chapter4/tests/t14/Makefile
@@ -1,0 +1,16 @@
+.PHONY: all
+
+# ----------------------------------------------------------------------------
+# Local Variables
+#
+# ============================================================================
+
+LIMIT ?= 100m
+IMAGE_NAME = krasninja/python-oom:0.1.0
+
+build:
+	@docker rmi ${IMAGE_NAME} 2>/dev/null || true
+	@docker build -t ${IMAGE_NAME} --rm --force-rm .
+
+run:
+	@docker run --rm -m ${LIMIT} ${IMAGE_NAME}

--- a/chapter4/tests/t14/README.md
+++ b/chapter4/tests/t14/README.md
@@ -1,0 +1,24 @@
+# OMM Container
+
+The test task demonstrates Docker container OOM feature in action.
+
+## How To Use
+
+1. Make sure the system has Docker installed.
+2. Run `make build`.
+3. Run `make run`.
+
+## Makefile Commands
+
+- `build`. Creates new Docker image. Image tag is `krasninja/python-oom:0.1.0`. If an image with the same tag exists it will be removed.
+- `run`. Run the container. Parameters:
+    - `LIMIT`. Specifies container memory limit. Default is 100m.
+
+## Examples
+
+- `make LIMIT=30m run`. Runs the container with memory limit 30 MB.
+
+## Links
+
+- Test task: https://github.com/saritasa-nest/saritasa-devops-camp/blob/main/chapter4%20-%20containers/l1/introduction.md#tasks-for-today
+- pre-commit: https://pre-commit.com/

--- a/chapter4/tests/t14/testtask/memory.py
+++ b/chapter4/tests/t14/testtask/memory.py
@@ -1,0 +1,10 @@
+import array
+from memory_profiler import memory_usage
+
+def allocate(size):
+    some_var = array.array('l', range(size))
+
+usage = memory_usage((allocate, (int(1e7),)))
+peak = max(usage)
+print(f"Usage over time: {usage}")
+print(f"Peak usage: {peak}")

--- a/chapter4/tests/t14/testtask/requirements.txt
+++ b/chapter4/tests/t14/testtask/requirements.txt
@@ -1,0 +1,1 @@
+memory_profiler


### PR DESCRIPTION
## Task

- create Makefile with the following targets:
  - `build`
  - `run`
    - `run` target should accept parameter `limit` that will set the desired max memory limit for the running docker container
    - if such parameter is not set, a default value of **100m** should be used
- `make run` should start the docker container and output content similar to 
  ```sh
  Usage over time: [20.67578125, 20.67578125, 35.30078125, 50.17578125, 64.80078125, 79.55078125, 94.30078125, 20.734375]
  Peak usage: 94.30078125
  ```
- `make run` with optional argument for memory set at **30m** should understand that container exited by error and in this case output the following line
  ```sh
  {exited false false false true false 0 137  2023-04-17T00:50:11.053754525Z 2023-04-17T00:50:13.721847306Z <nil>}
  ```
  which is content of the docker **State** value

- Task: https://github.com/saritasa-nest/saritasa-devops-camp/blob/main/chapter4%20-%20containers/l1/introduction.md#tasks-for-today
- Directory: `/chapter4/tests/t14`

## Usage

`make build && make run`

See README.md file for more information.
