### PR TITLE
feat: t15 - debug container task

### DIFF
--- a/chapter4/tests/t15/tcpdump.sh
+++ b/chapter4/tests/t15/tcpdump.sh
@@ -7,4 +7,3 @@ readonly DEBUG_CONTAINER_NAME="nginx-debug"
 
 docker start "${CONTAINER_NAME}" || docker run --rm --publish 8080:80 -d --name "${CONTAINER_NAME}" nginx
 docker run --rm -it --name "${DEBUG_CONTAINER_NAME}" --network container:"${CONTAINER_NAME}" nixery.dev/tcpdump tcpdump -i eth0 -A -nn port 80
-

--- a/chapter4/tests/t15/tcpdump.sh
+++ b/chapter4/tests/t15/tcpdump.sh
@@ -6,4 +6,4 @@ readonly CONTAINER_NAME="nginx"
 readonly DEBUG_CONTAINER_NAME="nginx-debug"
 
 docker start "${CONTAINER_NAME}" || docker run --rm --publish 8080:80 -d --name "${CONTAINER_NAME}" nginx
-docker run --rm -it --name "${DEBUG_CONTAINER_NAME}" --network container:"${CONTAINER_NAME}" nixery.dev/tcpdump tcpdump -i eth0 -A -nn port 80
+docker run --rm -it --cap-add="NET_ADMIN" --cap-add="NET_RAW" --cap-drop="ALL" --name "${DEBUG_CONTAINER_NAME}" --network container:"${CONTAINER_NAME}" nixery.dev/tcpdump tcpdump -i eth0 -A -nn port 80

--- a/chapter4/tests/t15/tcpdump.sh
+++ b/chapter4/tests/t15/tcpdump.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# The script starts nginx in docker and another container that runs tcpdum against nginx.
+set -eou pipefail
+
+readonly CONTAINER_NAME="nginx"
+readonly DEBUG_CONTAINER_NAME="nginx-debug"
+
+docker start "${CONTAINER_NAME}" || docker run --rm --publish 8080:80 -d --name "${CONTAINER_NAME}" nginx
+docker run --rm -it --name "${DEBUG_CONTAINER_NAME}" --network container:"${CONTAINER_NAME}" nixery.dev/tcpdump tcpdump -i eth0 -A -nn port 80
+


### PR DESCRIPTION
## Task

- start nginx container

`docker run --rm --publish 8080:80 --name nginx nginx`

- start another container with proper CAPs to debug TCP traffic in that container on port 80

Package your solution as a simple tcpdump.sh script and open PR.

- Task: https://github.com/saritasa-nest/saritasa-devops-camp/blob/main/chapter4%20-%20containers/l2/container-caps.md#test-task
- File: `chapter4/tests/t15/tcpdump.sh`

## Usage

1. Run the `tcpdump` script:

```
./tcpdump.sh
nginx
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
```

2. In another console run `curl http://localhost:8080`. You should get the `tcpdump` output in debug container:

```
12:25:39.735681 IP 172.17.0.1.42104 > 172.17.0.2.80: Flags [S], seq 2210769768, win 64240, options [mss 1460,sackOK,TS val 384122412 ecr 0,nop,wscale 7], length 0
E..<..@.@..h.........x.P...h........XT.........
..>,........
12:25:39.735697 IP 172.17.0.2.80 > 172.17.0.1.42104: Flags [S.], seq 1862538729, ack 2210769769, win 65160, options [mss 1460,sackOK,TS val 711420618 ecr 384122412,nop,wscale 7], length 0
E..<..@.@............P.xo......i....XT.........
*gj...>,....
12:25:39.735721 IP 172.17.0.1.42104 > 172.17.0.2.80: Flags [.], ack 1, win 502, options [nop,nop,TS val 384122412 ecr 711420618], length 0
E..4./@.@..o.........x.P...io.......XL.....
..>,*gj.
12:25:39.735986 IP 172.17.0.1.42104 > 172.17.0.2.80: Flags [P.], seq 1:78, ack 1, win 502, options [nop,nop,TS val 384122412 ecr 711420618], length 77: HTTP: GET / HTTP/1.1
E....0@.@..!.........x.P...io.......X......
..>,*gj.GET / HTTP/1.1
Host: localhost:8080
User-Agent: curl/8.0.1
Accept: */*
```

